### PR TITLE
profile pictures in navigation

### DIFF
--- a/client/components/Layout/Navigation.tsx
+++ b/client/components/Layout/Navigation.tsx
@@ -29,11 +29,12 @@ const StyledNav = styled(Nav)`
   justify-content: flex-end !important;
   width: 100%;
 
-  a {
-    border-bottom: 3px solid white;
-    border-top: 3px solid white;
+  & > a {
+    border-bottom: 2px solid white;
+    border-top: 2px solid white;
     padding: 0 !important;
     margin: 0.5rem 1rem 0.5rem 0.5rem;
+    transition: border 150ms ease;
 
     &:hover {
       border-bottom: 3px solid blue;
@@ -54,7 +55,7 @@ export default () => {
         </Link>
         <StyledNavbar.Toggle className="mr-2" />
         <StyledNavbar.Collapse>
-          <StyledNav navbar className="topNav ml-auto">
+          <StyledNav navbar className="ml-auto">
             <StyledNav.Link onClick={() => Router.pushRoute('/pipeline')}>
               Pipeline
             </StyledNav.Link>

--- a/client/components/Layout/Navigation.tsx
+++ b/client/components/Layout/Navigation.tsx
@@ -28,6 +28,17 @@ const StyledNav = styled(Nav)`
   flex-direction: row !important;
   justify-content: flex-end !important;
   width: 100%;
+
+  a {
+    border-bottom: 3px solid white;
+    border-top: 3px solid white;
+    padding: 0 !important;
+    margin: 0.5rem 1rem 0.5rem 0.5rem;
+
+    &:hover {
+      border-bottom: 3px solid blue;
+    }
+  }
 `;
 
 export default () => {

--- a/client/components/Layout/UserActions.tsx
+++ b/client/components/Layout/UserActions.tsx
@@ -5,7 +5,10 @@ import { Subscribe } from 'unstated';
 import UserContainer, { AuthState } from '../../containers/UserContainer';
 import { UnreachableCaseError } from '../../lib/errors';
 import { Link, Router } from '../../routes';
-import styled from 'styled-components'
+import styled from 'styled-components';
+import Dropdown from 'react-bootstrap/lib/Dropdown';
+import NavItem from 'react-bootstrap/lib/NavItem';
+import NavLink from 'react-bootstrap/lib/NavLink';
 
 export default () => (
   <Subscribe to={[UserContainer]}>
@@ -17,17 +20,19 @@ export default () => (
           return null;
         case AuthState.LoggedIn:
           return (
-            <NavDropdown
-              title={uc.state.user && uc.state.user.email}
-              id="navbar-auth-dropdown"
-            >
-              <NavDropdown.Item onClick={() => Router.pushRoute('/settings')}>
-                Settings
-              </NavDropdown.Item>
-              <NavDropdown.Item onClick={() => uc.logOut()}>
-                Log Out
-              </NavDropdown.Item>
-            </NavDropdown>
+            <Dropdown as={NavItem}>
+              <Dropdown.Toggle as={NavLink} id="navbar-auth-dropdown">
+                {uc.state.user && uc.state.user.email}
+              </Dropdown.Toggle>
+              <Dropdown.Menu>
+                <Dropdown.Item onClick={() => Router.pushRoute('/settings')}>
+                  Settings
+                </Dropdown.Item>
+                <Dropdown.Item onClick={() => uc.logOut()}>
+                  Log Out
+                </Dropdown.Item>
+              </Dropdown.Menu>
+            </Dropdown>
           );
         default:
           throw new UnreachableCaseError(uc.authState);

--- a/client/components/Layout/UserActions.tsx
+++ b/client/components/Layout/UserActions.tsx
@@ -1,14 +1,18 @@
 import React from 'react';
+import Dropdown from 'react-bootstrap/lib/Dropdown';
 import Nav from 'react-bootstrap/lib/Nav';
-import NavDropdown from 'react-bootstrap/lib/NavDropdown';
+import NavItem from 'react-bootstrap/lib/NavItem';
+import NavLink from 'react-bootstrap/lib/NavLink';
+import styled from 'styled-components';
+import Image from 'react-bootstrap/lib/Image';
 import { Subscribe } from 'unstated';
 import UserContainer, { AuthState } from '../../containers/UserContainer';
 import { UnreachableCaseError } from '../../lib/errors';
-import { Link, Router } from '../../routes';
-import styled from 'styled-components';
-import Dropdown from 'react-bootstrap/lib/Dropdown';
-import NavItem from 'react-bootstrap/lib/NavItem';
-import NavLink from 'react-bootstrap/lib/NavLink';
+import { Router } from '../../routes';
+
+const ProfileImage = styled(Image)`
+  max-height: 32px;
+`;
 
 export default () => (
   <Subscribe to={[UserContainer]}>
@@ -20,9 +24,13 @@ export default () => (
           return null;
         case AuthState.LoggedIn:
           return (
-            <Dropdown as={NavItem}>
+            <Dropdown as={NavItem} alignRight>
               <Dropdown.Toggle as={NavLink} id="navbar-auth-dropdown">
-                {uc.state.user && uc.state.user.email}
+                {uc.user && uc.user.photo ? (
+                  <ProfileImage src={uc.user.photo} roundedCircle />
+                ) : uc.user ? (
+                  uc.user.email
+                ) : null}
               </Dropdown.Toggle>
               <Dropdown.Menu>
                 <Dropdown.Item onClick={() => Router.pushRoute('/settings')}>

--- a/client/schemas/_utils.ts
+++ b/client/schemas/_utils.ts
@@ -22,3 +22,9 @@ export const makeRequired = (schema: JSONSchema6, keys: string[]) => ({
   ...schema,
   required: uniq(keys.concat(schema.required)),
 });
+
+/** Given a schema, makes all fields optional. */
+export const makePartial = (schema: JSONSchema6) => ({
+  ...schema,
+  required: [],
+});

--- a/client/stylesheets/application.scss
+++ b/client/stylesheets/application.scss
@@ -74,17 +74,6 @@ body {
     }
 }
 
-.topNav a {
-    border-bottom: 3px solid white;
-    border-top: 3px solid white;
-    padding: 0 !important;
-    margin: .5rem 1rem .5rem .5rem;
-
-    &:hover {
-        border-bottom: 3px solid blue;
-    }
-}
-
 .pipelineLayout {
     margin: 5rem 5vw 0vh 5vw;
     padding: 0;

--- a/config/default.json
+++ b/config/default.json
@@ -31,7 +31,7 @@
       "logoutRedirect": "http://localhost:3000",
       "successRedirect": "/pipeline",
       "domain": "mydomain.auth0.com",
-      "scopes": ["profile openid"]
+      "scope": ["openid", "email", "profile"]
     },
     "cookie": {
       "enabled": true,

--- a/server/services/users/users.hooks.ts
+++ b/server/services/users/users.hooks.ts
@@ -1,15 +1,13 @@
 import { hooks as authHooks } from '@feathersjs/authentication';
 import Ajv from 'ajv';
+import { JSONSchema6 } from 'json-schema';
 import { userSchema } from '../../../client/schemas/user';
+import { makePartial } from '../../../client/schemas/_utils';
 
 const { authenticate } = authHooks;
-const ajv = new Ajv({ allErrors: true, $data: true });
 
-const partialSchema = {
-  type: userSchema.type,
-  properties: userSchema.properties,
-  additionalProperties: false,
-};
+const ajv = new Ajv({ allErrors: true, $data: true });
+const partialSchema = makePartial(userSchema as JSONSchema6);
 
 const customizeOAuthProfile = () => async (context) => {
   if (context.data.auth0 && context.data.auth0.profile) {
@@ -34,6 +32,7 @@ export default {
     ],
     update: [
       authenticate('jwt'),
+      customizeOAuthProfile(),
       // validateSchema(partialSchema, <AjvOrNewable>ajv),
     ],
     patch: [


### PR DESCRIPTION
When available, uses profile pictures in the navigation bar instead of the user email. This is meant to be used as an example of how profile pictures can be used in Magic Wand.