### PR TITLE
refactor google drive

### DIFF
--- a/client/components/Pipeline/Kanban.tsx
+++ b/client/components/Pipeline/Kanban.tsx
@@ -3,7 +3,12 @@ import { DragDropContext } from 'react-beautiful-dnd';
 import styled from 'styled-components';
 import client from '../../lib/client';
 import transformData from '../../lib/pipelineUtils';
-import {  Status, archivedStates, companySchema, Company } from '../../schemas/company';
+import {
+  Status,
+  archivedStates,
+  companySchema,
+  Company,
+} from '../../schemas/company';
 import Column from './Column';
 import CustomDropdown from './Dropdown';
 import GroupButton from './GroupButton';
@@ -61,7 +66,7 @@ export default class Kanban extends PureComponent<KanbanProps, KanbanState> {
       const res = (await client.service('api/companies').find({
         query: {
           status: {
-            $nin: archivedStates
+            $nin: archivedStates,
           },
         },
       })) as Paginated<Company>;
@@ -157,20 +162,6 @@ export default class Kanban extends PureComponent<KanbanProps, KanbanState> {
       console.error(e);
     }
 
-    /*
-     * Generate the snapshot and prevote documents.
-     */
-    if (newForeign.id === Status.Pitching) {
-      try {
-        client.service('api/gdrive').create({
-          document_type: DocumentTypes.Both,
-          company_id: draggedObj.id,
-        })
-      } catch(e) {
-        console.log(e);
-      }
-    }
-
     const newState = {
       columns: {
         ...this.state.columns,
@@ -223,7 +214,7 @@ export default class Kanban extends PureComponent<KanbanProps, KanbanState> {
   render() {
     return (
       <div>
-        <h2>{this.props.user.first_name + " " + this.props.user.last_name}</h2>
+        <h2>{this.props.user.first_name + ' ' + this.props.user.last_name}</h2>
         <div className="pipelineButtons">
           <CustomDropdown partners={this.state.partnerNames} />
           <IndividualButton
@@ -251,7 +242,15 @@ export default class Kanban extends PureComponent<KanbanProps, KanbanState> {
                   );
                 })}
                 <div className="addCompanyDiv">
-                  <img onClick={() => window.open("https://dormroomfund.typeform.com/to/H90ZNU", "_blank")} src="/static/Add_Company_Button.png"/>
+                  <img
+                    onClick={() =>
+                      window.open(
+                        'https://dormroomfund.typeform.com/to/H90ZNU',
+                        '_blank'
+                      )
+                    }
+                    src="/static/Add_Company_Button.png"
+                  />
                 </div>
               </AppContainer>
             </DragDropContext>

--- a/client/schemas/company.ts
+++ b/client/schemas/company.ts
@@ -42,6 +42,11 @@ export interface PartnerVoteObj {
   name: string;
 }
 
+export interface CompanyLink {
+  name?: string;
+  url?: string;
+}
+
 export interface Company {
   id?: number;
   name: string;
@@ -52,10 +57,7 @@ export interface Company {
   tags?: string[];
   status: Status;
   contact_email: string;
-  company_links?: {
-    name?: string;
-    url?: string;
-  }[];
+  company_links?: CompanyLink[];
   created_at?: string;
   updated_at?: string;
 

--- a/client/schemas/gdrive.ts
+++ b/client/schemas/gdrive.ts
@@ -1,18 +1,14 @@
-/*
- * Describes JSON validation schema for the gDriveService.
- */
-
 export enum DocumentTypes {
   Prevote = 'prevote',
-
   Snapshot = 'snapshot',
-
-  Both = 'both',
 }
 
+/* Describes JSON validation schema for the gDriveService. */
 export interface GoogleDriveDocument {
   document_type: DocumentTypes;
   company_id: number;
+
+  document_id?: string;
 }
 
 export const gDriveSchema = {

--- a/server/services/companies/companies.hooks.ts
+++ b/server/services/companies/companies.hooks.ts
@@ -1,6 +1,12 @@
 import Ajv from 'ajv';
-import { alterItems, fastJoin, keep } from 'feathers-hooks-common';
-import { companySchema } from '../../../client/schemas/company';
+import { alterItems, fastJoin, keep, iff } from 'feathers-hooks-common';
+import {
+  companySchema,
+  Company,
+  Status,
+} from '../../../client/schemas/company';
+import { HookContext } from '@feathersjs/feathers';
+import { DocumentTypes } from '../../../client/schemas/gdrive';
 
 const ajv = new Ajv({ allErrors: true, $data: true });
 
@@ -71,6 +77,23 @@ const pointPartners = {
     },
   },
 };
+
+const isPitching = async (ctx: HookContext<Company>) =>
+  ctx.result.status === Status.Pitching;
+
+const generateGoogleDriveDocuments = async (ctx: HookContext<Company>) => {
+  await Promise.all([
+    ctx.app.service('api/gdrive').create({
+      document_type: DocumentTypes.Prevote,
+      company_id: ctx.result.id,
+    }),
+    ctx.app.service('api/gdrive').create({
+      document_type: DocumentTypes.Snapshot,
+      company_id: ctx.result.id,
+    }),
+  ]);
+};
+
 export default {
   before: {
     all: [],
@@ -99,7 +122,7 @@ export default {
     all: [fastJoin(votedPartners), fastJoin(pointPartners)],
     find: [],
     get: [],
-    create: [],
+    create: [iff(isPitching, generateGoogleDriveDocuments)],
     update: [],
     patch: [],
     remove: [],

--- a/server/services/companies/companies.hooks.ts
+++ b/server/services/companies/companies.hooks.ts
@@ -123,8 +123,8 @@ export default {
     find: [],
     get: [],
     create: [iff(isPitching, generateGoogleDriveDocuments)],
-    update: [],
-    patch: [],
+    update: [iff(isPitching, generateGoogleDriveDocuments)],
+    patch: [iff(isPitching, generateGoogleDriveDocuments)],
     remove: [],
   },
 

--- a/server/services/gdrive/gdrive.service.ts
+++ b/server/services/gdrive/gdrive.service.ts
@@ -3,7 +3,7 @@
  * snapshots or prevote documents.
  *
  * {
- *   document_type: 'prevote' or 'snapshot' or 'both'
+ *   document_type: 'prevote' or 'snapshot'
  *   company_id:
  * }
  *
@@ -12,11 +12,14 @@
 import errors from '@feathersjs/errors';
 import config from 'config';
 import { google } from 'googleapis';
+import util from 'util';
 import App from '../../../client/schemas/app';
-import { DocumentTypes } from '../../../client/schemas/gdrive';
-import hooks from './gdrive.hooks';
-import logger from '../../logger';
 import { Company } from '../../../client/schemas/company';
+import { GoogleDriveDocument } from '../../../client/schemas/gdrive';
+import logger from '../../logger';
+import hooks from './gdrive.hooks';
+
+const cfg: Record<string, string> = config.get('googleDrive');
 
 class GDriveService {
   private app!: App;
@@ -25,100 +28,74 @@ class GDriveService {
     this.app = app;
   }
 
-  async create(data) {
-    /*
-     * Get the documents we need to create
-     */
-    let toCreate: Array<DocumentTypes>;
-    if (data.document_type === DocumentTypes.Both) {
-      toCreate = [DocumentTypes.Prevote, DocumentTypes.Snapshot];
-    } else if (data.document_type === DocumentTypes.Snapshot) {
-      toCreate = [DocumentTypes.Snapshot];
-    } else {
-      toCreate = [DocumentTypes.Prevote];
-    }
-
-    let company: Company;
-    try {
-      company = await this.app.service('api/companies').get(data.company_id);
-
-      /* Check if we already created any of these documents. */
-      toCreate = toCreate.filter(
-        (doc) => !company.company_links || !company.company_links[doc]
-      );
-
-      if (toCreate.length === 0) return;
-    } catch (e) {
-      throw new errors.BadRequest('Invalid Company Id');
-    }
-
-    /*
-     * Create and authenticate the jwt client.
-     */
+  /**
+   * Creates a google drive client for usage.
+   */
+  private async getDriveClient() {
+    /* Create and authenticate the jwt client. */
     const jwtClient = new google.auth.JWT(
-      config.googleDrive.googleServiceEmail,
+      cfg.googleServiceEmail,
       null,
-      config.googleDrive.googleServiceKey,
+      cfg.googleServiceKey,
       ['https://www.googleapis.com/auth/drive']
     );
 
-    jwtClient.authorize((err) => {
-      if (err) {
-        logger.error('error while authorizing google drive client', err);
-        throw new errors.BadRequest('Google Drive Authentication Error');
-      }
-    });
+    try {
+      await jwtClient.authorize();
+    } catch (e) {
+      logger.error('error while authorizing google drive client', e);
+      throw new errors.GeneralError('Google Drive Authentication Error');
+    }
 
     const drive = google.drive({
       version: 'v3',
       auth: jwtClient,
     });
 
-    toCreate.forEach(async (docType) => {
-      /* Get the relevant folder we want to store this document in. */
-      const folder = config.get(
-        `googleDrive.${docType}FolderIds.${company.team}`
-      );
+    return drive;
+  }
 
-      const documentName = `[${data.company_id}] ${
-        company.name
-      } ${docType.toUpperCase()}`;
+  async create(data: GoogleDriveDocument) {
+    const { document_type, company_id } = data;
+    const company = await this.app.service('api/companies').get(company_id);
 
-      await drive.files.create(
-        {
-          supportsTeamDrives: true,
-          resource: {
-            name: documentName,
-            mimeType: 'application/vnd.google-apps.document',
-            parents: [folder],
-          },
+    if (company.company_links.some(({ name }) => name === document_type)) {
+      return data;
+    }
+    if (!company.team) {
+      throw new errors.Unprocessable('company has no assigned team');
+    }
+
+    /* Get the relevant folder we want to store this document in. */
+    const folder = config.get(
+      `googleDrive.${document_type}FolderIds.${company.team}`
+    );
+
+    const documentName = `[${company_id}] ${
+      company.name
+    } ${document_type.toUpperCase()}`;
+
+    const drive = await this.getDriveClient();
+    const createDriveFile = util.promisify(drive.files.create);
+
+    try {
+      const res = await createDriveFile({
+        supportsTeamDrives: true,
+        resource: {
+          name: documentName,
+          mimeType: 'application/vnd.google-apps.document',
+          parents: [folder],
         },
-        async (err, res) => {
-          if (err) {
-            logger.error('error while creating file', err);
-            throw new errors.BadRequest('Google Drive File Error');
-          }
+      });
 
-          const docLink = `https://docs.google.com/document/d/${res.data.id}`;
-
-          // Update company in case of stale data.
-          const company = await this.app
-            .service('api/companies')
-            .get(data.company_id);
-          const newLinks = [
-            ...company.company_links,
-            { name: docType, url: docLink },
-          ];
-
-          /* Update the company links. */
-          await this.app.service('api/companies').patch(data.company_id, {
-            company_links: newLinks,
-          });
-        }
-      );
-    });
-
-    return data;
+      return {
+        ...data,
+        document_id: res.data.id,
+      };
+    } catch (e) {
+      logger.error('error while creating file', e);
+      throw new errors.BadRequest('Google Drive File Error');
+    }
   }
 }
 


### PR DESCRIPTION
This PR makes the following improvements:

- Factors out the insertion of the links into an after hook (separation of concerns)
- Unifies async calls into async/await style (fuck Google Drive)
- Moves snapshot creation from Kanban.tsx to an after hook in companies, removing a round trip and improving robustness
- Fixes the [snapshot multiple creation bug](https://trello.com/c/9pA1Xsk8/87-snapshot-generates-more-than-once-bug) caused by data mismatch