### PR TITLE
Update README with solution to postgres error in install/run

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ $ make test
 
 For a full list of commands, consult the `Makefile`.
 
+If you installed Postgres via Homebrew, you may get the error 
+`psql: FATAL: role “postgres” does not exist`. 
+[To resolve](https://stackoverflow.com/questions/15301826/psql-fatal-role-postgres-does-not-exist#comment101477151_15309551), 
+run `/usr/local/opt/postgresql/bin/createuser -s postgres`.
+
 ## Scaffolding
 
 Use the feathers scaffolding tool to generate code:


### PR DESCRIPTION
While installing and running, I got a lengthy error about db connection. Nested in a couple other errors, it boiled down to `error: "role "postgres" does not exist"`. It turns out installing postgres with homebrew can sometimes come without a role named 'postgres' (which we need here). This adds a solution to make setup easier for others.

Apologies if there's a better place than the README for this - lmk where to put it :)