### PR TITLE
Vinai/test db infra

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -86,8 +86,8 @@ blocks:
           - sem-service start postgres
           - make ci-database
           - sem-service status postgres
-          - alias pg_dump="pg_dump -U postgres -h 0.0.0.0"
-          - alias pg_restore="pg_restore -U postgres -h 0.0.0.0"
+          - export PGUSER=postgres
+          - export PGHOST=0.0.0.0
       jobs:
         - name: smoke test
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -86,8 +86,6 @@ blocks:
           - sem-service start postgres
           - make ci-database
           - sem-service status postgres
-          - alias pg_dump="pg_dump -h 0.0.0.0"
-          - alias pg_restore="pg_restore -h 0.0.0.0"
       jobs:
         - name: smoke test
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -86,6 +86,8 @@ blocks:
           - sem-service start postgres
           - make ci-database
           - sem-service status postgres
+          - alias pg_dump="pg_dump -U postgres -h 0.0.0.0"
+          - alias pg_restore="pg_restore -U postgres -h 0.0.0.0"
       jobs:
         - name: smoke test
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -94,3 +94,6 @@ blocks:
           commands:
             - sudo apt-get install -y xvfb libgtk2.0-0 libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2
             - make ci-cypress
+        - name: make jest
+          commands:
+            - make jest

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -86,6 +86,8 @@ blocks:
           - sem-service start postgres
           - make ci-database
           - sem-service status postgres
+          - alias pg_dump="pg_dump -h 0.0.0.0"
+          - alias pg_restore="pg_restore -h 0.0.0.0"
       jobs:
         - name: smoke test
           commands:

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,10 @@ test-db:
 
 # Runs the test suite.
 jest:
+	$(NPX) knex seed:run --knexfile test/testdb_knexfile.ts
+	pg_dump -Fc magic_wand_test > /tmp/magic_wand_test.dump
 	$(NPX) jest
+	pg_restore -c -d magic_wand_test /tmp/magic_wand_test.dump
 
 # Runs Cypress CI tests
 ci-cypress:
@@ -99,7 +102,10 @@ ci-cypress:
 
 # Runts Cypress tests
 cypress-run:
+	$(NPX) knex seed:run --knexfile test/testdb_knexfile.ts
+	pg_dump -Fc magic_wand_test > /tmp/magic_wand_test.dump
 	$(NPX) cypress run
+	pg_restore -c -d magic_wand_test /tmp/magic_wand_test.dump
 
 # Opens Cypress
 cypress-open:
@@ -107,8 +113,11 @@ cypress-open:
 
 # Runs the full test suite.
 test:
+	$(NPX) knex seed:run --knexfile test/testdb_knexfile.ts
+	pg_dump -Fc magic_wand_test > /tmp/magic_wand_test.dump
 	$(NPX) jest
 	$(NPX) cypress run
+	pg_restore -c -d magic_wand_test /tmp/magic_wand_test.dump
 
 ################################################################################
 

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ smoke:
 # Makes the test database
 test-db:
 	createdb magic_wand_test
-	
+
 # Runs the test suite.
 jest:
 	$(NPX) jest
@@ -113,8 +113,11 @@ test:
 ################################################################################
 
 # Initialize the database for CI
+# NOTE: We should create two different databases as the smoke test will test the production setup
+# 		whereas jest will set NODE_ENV=test and use the testing database.
 ci-database:
 	createdb -U postgres -h 0.0.0.0 magic_wand
+	createdb -U postgres -h 0.0.0.0 magic_wand_test
 	make migrate
 	make seed
 

--- a/Makefile
+++ b/Makefile
@@ -90,9 +90,9 @@ test-db:
 # Runs the test suite.
 jest:
 	$(NPX) knex seed:run --knexfile test/testdb_knexfile.ts
-	pg_dump -h 0.0.0.0 -Fc magic_wand_test > /tmp/magic_wand_test.dump
+	pg_dump -U postgres -h 0.0.0.0 -Fc magic_wand_test > /tmp/magic_wand_test.dump
 	$(NPX) jest
-	pg_restore -h 0.0.0.0 -c -d magic_wand_test /tmp/magic_wand_test.dump
+	pg_restore -U -h 0.0.0.0 -c -d magic_wand_test /tmp/magic_wand_test.dump
 
 # Runs Cypress CI tests
 ci-cypress:
@@ -103,9 +103,9 @@ ci-cypress:
 # Runts Cypress tests
 cypress-run:
 	$(NPX) knex seed:run --knexfile test/testdb_knexfile.ts
-	pg_dump -h 0.0.0.0 -Fc magic_wand_test > /tmp/magic_wand_test.dump
+	pg_dump -U postgres -h 0.0.0.0 -Fc magic_wand_test > /tmp/magic_wand_test.dump
 	$(NPX) cypress run
-	pg_restore -h 0.0.0.0 -c -d magic_wand_test /tmp/magic_wand_test.dump
+	pg_restore -U -h 0.0.0.0 -c -d magic_wand_test /tmp/magic_wand_test.dump
 
 # Opens Cypress
 cypress-open:
@@ -114,10 +114,10 @@ cypress-open:
 # Runs the full test suite.
 test:
 	$(NPX) knex seed:run --knexfile test/testdb_knexfile.ts
-	pg_dump -h 0.0.0.0 -Fc magic_wand_test > /tmp/magic_wand_test.dump
+	pg_dump -U postgres -h 0.0.0.0 -Fc magic_wand_test > /tmp/magic_wand_test.dump
 	$(NPX) jest
 	$(NPX) cypress run
-	pg_restore -h 0.0.0.0 -c -d magic_wand_test /tmp/magic_wand_test.dump
+	pg_restore -U -h 0.0.0.0 -c -d magic_wand_test /tmp/magic_wand_test.dump
 
 ################################################################################
 

--- a/Makefile
+++ b/Makefile
@@ -90,9 +90,9 @@ test-db:
 # Runs the test suite.
 jest:
 	$(NPX) knex seed:run --knexfile test/testdb_knexfile.ts
-	pg_dump -Fc magic_wand_test > /tmp/magic_wand_test.dump
+	pg_dump -h 0.0.0.0 -Fc magic_wand_test > /tmp/magic_wand_test.dump
 	$(NPX) jest
-	pg_restore -c -d magic_wand_test /tmp/magic_wand_test.dump
+	pg_restore -h 0.0.0.0 -c -d magic_wand_test /tmp/magic_wand_test.dump
 
 # Runs Cypress CI tests
 ci-cypress:
@@ -103,9 +103,9 @@ ci-cypress:
 # Runts Cypress tests
 cypress-run:
 	$(NPX) knex seed:run --knexfile test/testdb_knexfile.ts
-	pg_dump -Fc magic_wand_test > /tmp/magic_wand_test.dump
+	pg_dump -h 0.0.0.0 -Fc magic_wand_test > /tmp/magic_wand_test.dump
 	$(NPX) cypress run
-	pg_restore -c -d magic_wand_test /tmp/magic_wand_test.dump
+	pg_restore -h 0.0.0.0 -c -d magic_wand_test /tmp/magic_wand_test.dump
 
 # Opens Cypress
 cypress-open:
@@ -114,10 +114,10 @@ cypress-open:
 # Runs the full test suite.
 test:
 	$(NPX) knex seed:run --knexfile test/testdb_knexfile.ts
-	pg_dump -Fc magic_wand_test > /tmp/magic_wand_test.dump
+	pg_dump -h 0.0.0.0 -Fc magic_wand_test > /tmp/magic_wand_test.dump
 	$(NPX) jest
 	$(NPX) cypress run
-	pg_restore -c -d magic_wand_test /tmp/magic_wand_test.dump
+	pg_restore -h 0.0.0.0 -c -d magic_wand_test /tmp/magic_wand_test.dump
 
 ################################################################################
 

--- a/Makefile
+++ b/Makefile
@@ -90,9 +90,9 @@ test-db:
 # Runs the test suite.
 jest:
 	$(NPX) knex seed:run --knexfile test/testdb_knexfile.ts
-	pg_dump -U postgres -h 0.0.0.0 -Fc magic_wand_test > /tmp/magic_wand_test.dump
+	pg_dump -Fc magic_wand_test > /tmp/magic_wand_test.dump
 	$(NPX) jest
-	pg_restore -U -h 0.0.0.0 -c -d magic_wand_test /tmp/magic_wand_test.dump
+	pg_restore -c -d magic_wand_test /tmp/magic_wand_test.dump
 
 # Runs Cypress CI tests
 ci-cypress:
@@ -103,9 +103,9 @@ ci-cypress:
 # Runts Cypress tests
 cypress-run:
 	$(NPX) knex seed:run --knexfile test/testdb_knexfile.ts
-	pg_dump -U postgres -h 0.0.0.0 -Fc magic_wand_test > /tmp/magic_wand_test.dump
+	pg_dump -Fc magic_wand_test > /tmp/magic_wand_test.dump
 	$(NPX) cypress run
-	pg_restore -U -h 0.0.0.0 -c -d magic_wand_test /tmp/magic_wand_test.dump
+	pg_restore -c -d magic_wand_test /tmp/magic_wand_test.dump
 
 # Opens Cypress
 cypress-open:
@@ -114,10 +114,10 @@ cypress-open:
 # Runs the full test suite.
 test:
 	$(NPX) knex seed:run --knexfile test/testdb_knexfile.ts
-	pg_dump -U postgres -h 0.0.0.0 -Fc magic_wand_test > /tmp/magic_wand_test.dump
+	pg_dump -Fc magic_wand_test > /tmp/magic_wand_test.dump
 	$(NPX) jest
 	$(NPX) cypress run
-	pg_restore -U -h 0.0.0.0 -c -d magic_wand_test /tmp/magic_wand_test.dump
+	pg_restore -c -d magic_wand_test /tmp/magic_wand_test.dump
 
 ################################################################################
 

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,11 @@ smoke:
 	make production &
 	$(NPX) wait-on http://localhost:3000/ -t 90000 && echo "success"
 
+
+# Makes the test database
+test-db:
+	createdb magic_wand_test
+	
 # Runs the test suite.
 jest:
 	$(NPX) jest
@@ -101,7 +106,7 @@ cypress-open:
 	$(NPX) cypress open
 
 # Runs the full test suite.
-test: 
+test:
 	$(NPX) jest
 	$(NPX) cypress run
 
@@ -116,10 +121,12 @@ ci-database:
 # Migrate the database to the latest migration.
 migrate:
 	$(NPX) knex migrate:latest --knexfile knexfile.ts
+	$(NPX) knex migrate:latest --knexfile test/testdb_knexfile.ts
 
 # Roll back the database to before the latest mgiration.
 migrate-rollback:
 	$(NPX) knex migrate:rollback --knexfile knexfile.ts
+	$(NPX) knex migrate:rollback --knexfile test/testdb_knexfile.ts
 
 seed:
-	$(NPX)  knex seed:run --knexfile knexfile.ts
+	$(NPX) knex seed:run --knexfile knexfile.ts

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Make sure you have Postgres installed already. To install:
 ```
 $ make install
 $ createdb magic_wand
-$ createdb magic_wand_gtest
+$ createdb magic_wand_test
 $ make migrate
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Make sure you have Postgres installed already. To install:
 ```
 $ make install
 $ createdb magic_wand
+$ createdb magic_wand_gtest
 $ make migrate
 ```
 

--- a/config/test.json
+++ b/config/test.json
@@ -1,0 +1,6 @@
+{
+  "postgres": {
+    "client": "pg",
+    "connection": "postgres://postgres:@localhost:5432/magic_wand_test"
+  }
+}

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -1,5 +1,9 @@
 import rp from 'request-promise';
 import { format } from 'url';
+
+import app from '../server/app';
+import * as config from '../config/test.json';
+
 /*
 import { get, listen } from '../server/app';
 
@@ -59,8 +63,20 @@ describe('Feathers application tests (with jest)', () => {
 });
 */
 
-describe('Example Test', () => {
-  it('should vacuously work', () => {
-    expect(true).toEqual(true);
+describe('App Tests', () => {
+  it('should be using the test database', () => {
+    // The configurations loaded in the app
+    const {
+      settings: {
+        postgres: { connection: appConnection },
+      },
+    } = app;
+
+    // What the actual test configurations should be
+    const {
+      postgres: { connection: actualTestConnection },
+    } = config;
+
+    expect(appConnection).toEqual(actualTestConnection);
   });
 });

--- a/test/services/companies.test.ts
+++ b/test/services/companies.test.ts
@@ -1,0 +1,26 @@
+import assert from 'assert';
+import app from '../../server/app';
+
+describe('Companies Test', () => {
+  it('should do something', () => {
+    expect(true).toEqual(true);
+  });
+
+  it('registered the companies service', async () => {
+    const service = app.service('/api/companies');
+
+    assert.ok(service, 'Registered the service');
+  });
+
+  it('contains the seed companies data', async () => {
+    const service = app.service('/api/companies');
+
+    const company = await service.find({
+      query: {
+        name: 'Tesla 2.0',
+      },
+    });
+
+    assert.equal(company.total, 1, 'One company called Tesla 2.0');
+  });
+});

--- a/test/services/votes.test.ts
+++ b/test/services/votes.test.ts
@@ -1,5 +1,9 @@
+import app from '../../server/app';
+
 describe('Votes Test', () => {
   it('should do something', () => {
     expect(true).toEqual(true);
   });
+
+  it('should register the /api/vote service', () => {});
 });

--- a/test/services/votes.test.ts
+++ b/test/services/votes.test.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import app from '../../server/app';
 
 describe('Votes Test', () => {
@@ -5,5 +6,9 @@ describe('Votes Test', () => {
     expect(true).toEqual(true);
   });
 
-  it('should register the /api/vote service', () => {});
+  it('registered the votes service', async () => {
+    const service = app.service('/api/votes');
+
+    assert.ok(service, 'Registered the service');
+  });
 });

--- a/test/testdb_knexfile.ts
+++ b/test/testdb_knexfile.ts
@@ -1,0 +1,33 @@
+/*
+ * Knexfile that is used to manage the migrations for the test database. Note that test
+ * database schema/structure should manage the local database schema/structure.
+ */
+
+import t from 'tcomb';
+import * as config from '../config/test.json';
+
+const {
+  postgres: { client, connection },
+} = config;
+
+t.String(client);
+t.String(connection);
+
+const knexConfig = {
+  client: 'pg',
+  connection,
+  migrations: {
+    directory: '../server/migrations',
+    tableName: 'knex_migrations',
+  },
+  seeds: {
+    directory: '../server/seeds',
+  },
+  pool: {
+    min: 2,
+    max: 10,
+  },
+  useNullAsDefault: false,
+};
+
+module.exports = knexConfig;


### PR DESCRIPTION
This is the infrastructure needed to create a local database for testing. This allows running tests that modify some sort of database state independently of the local database (magic_wand) that could in a special state for local development. 

Note that the testing database (magic_wand_test) should follow the same migrations as the local database (magic_wand). Hence each `make migrate` and  `make rollback` should affect both databases. 

The sequence for tests cases is now as follows:

1. Seed the test database
2. Create a dump of the test database (Used to preserve migrations which take a lot of time to do every test)
3. run the test cases
4. Restore the test database to its seeded version 

This PR also adds `make jest` to the CI. 
