### PR TITLE
Fix some gdrive bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,14 +17,14 @@ install:
 # Starts the server in development mode, restarting when changes detected.
 # TODO: Check if style variables have changed and regenerate.
 dev:
-	npx nodemon --exec ts-node server/
+	NODE_ENV=development $(NPX) nodemon --exec ts-node server/
 
 dev-debug:
-	DEBUG=knex:query LOGLEVEL=debug npx nodemon --exec ts-node server/
+	NODE_ENV=development DEBUG=knex:query LOGLEVEL=debug $(NPX) nodemon --exec ts-node server/
 
 # Starts the server in development mode.
 start: style-variables
-	$(NPX) ts-node server/
+	NODE_ENV=development $(NPX) ts-node server/
 
 style-variables:
 	$(NPX) scss-to-json client/stylesheets/_colors.scss > client/stylesheets/colors.json

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -25,8 +25,8 @@
       "San Francisco": "SAN_FRANCISCO_FOLDER_ID"
     },
     "templateIds": {
-      "external-snapshot": "EXTERNAL_SNAPSHOT_TEMPLATE_ID",
-      "internal-snapshot": "INTERNAL_SNAPSHOT_TEMPLATE_ID",
+      "External Snapshot": "EXTERNAL_SNAPSHOT_TEMPLATE_ID",
+      "Internal Snapshot": "INTERNAL_SNAPSHOT_TEMPLATE_ID",
       "prevote": "PREVOTE_SNAPSHOT_TEMPLATE_ID"
     }
   }

--- a/config/default.json
+++ b/config/default.json
@@ -56,8 +56,8 @@
       "San Francisco": "your SAN_FRANCISCO_FOLDER_ID"
     },
     "templateIds": {
-      "external-snapshot": "your EXTERNAL_SNAPSHOT_TEMPLATE_ID",
-      "internal-snapshot": "your INTERNAL_SNAPSHOT_TEMPLATE_ID",
+      "External Snapshot": "your EXTERNAL_SNAPSHOT_TEMPLATE_ID",
+      "Internal Snapshot": "your INTERNAL_SNAPSHOT_TEMPLATE_ID",
       "prevote": "your PREVOTE_SNAPSHOT_TEMPLATE_ID"
     }
   }

--- a/server/services/companies/companies.hooks.ts
+++ b/server/services/companies/companies.hooks.ts
@@ -157,9 +157,24 @@ export default {
     ],
     find: [],
     get: [],
-    create: [iff(isPitching, generateGoogleDriveDocuments)],
-    update: [iff(isPitching, generateGoogleDriveDocuments)],
-    patch: [iff(isPitching, generateGoogleDriveDocuments)],
+    create: [
+      iff(
+        process.env.NODE_ENV === 'production' && isPitching,
+        generateGoogleDriveDocuments
+      ),
+    ], // only create in prod
+    update: [
+      iff(
+        process.env.NODE_ENV === 'production' && isPitching,
+        generateGoogleDriveDocuments
+      ),
+    ], // only create in prod
+    patch: [
+      iff(
+        process.env.NODE_ENV === 'production' && isPitching,
+        generateGoogleDriveDocuments
+      ),
+    ], // only create in prod
     remove: [],
   },
 


### PR DESCRIPTION
Create google docs/folders only in production, 
Fix bugs where templates where not getting created
Updated NODE_ENV=development whenever there is development

This should fix:

https://trello.com/c/Oq4wBf6D/129-setting-pitch-date-doesnt-work
https://trello.com/c/y17GOMnt/131-moving-cards-to-pitching-gives-non-crashing-error
https://trello.com/c/LutT7Tub/136-google-drive-templates-should-not-be-created-in-development-mode