### PR TITLE
Warning message for overdue applications

### DIFF
--- a/client/components/CompanyCard/CompanyCard.tsx
+++ b/client/components/CompanyCard/CompanyCard.tsx
@@ -88,6 +88,16 @@ export default class CompanyCard extends React.Component<CompanyCardProps> {
     );
   }
 
+  renderOverdueWarning() {
+    const daysSinceApplied =
+      (+new Date() - +this.props.company.createdAt) / (1000 * 60 * 60 * 24);
+
+    if (this.props.company.status !== Status.Applied && daysSinceApplied < 6)
+      return null;
+
+    return <p> Applied {daysSinceApplied} days ago </p>;
+  }
+
   render() {
     return (
       <div className="cards">
@@ -111,6 +121,7 @@ export default class CompanyCard extends React.Component<CompanyCardProps> {
                       </Card.Link>
                     </Link>
                   </Card.Text>
+                  {this.renderOverdueWarning()}
                   <ButtonGroup aria-label="company card actions">
                     {this.renderPartnerAssignmentButton()}
                     {this.renderVotingButton()}

--- a/client/components/CompanyCard/CompanyCard.tsx
+++ b/client/components/CompanyCard/CompanyCard.tsx
@@ -92,7 +92,7 @@ export default class CompanyCard extends React.Component<CompanyCardProps> {
     const daysSinceApplied =
       (+new Date() - +this.props.company.createdAt) / (1000 * 60 * 60 * 24);
 
-    if (this.props.company.status !== Status.Applied && daysSinceApplied < 6)
+    if (this.props.company.status !== Status.Applied || daysSinceApplied < 6)
       return null;
 
     return <p> Applied {daysSinceApplied} days ago </p>;

--- a/client/components/Pipeline/Kanban.tsx
+++ b/client/components/Pipeline/Kanban.tsx
@@ -70,6 +70,9 @@ export default class Kanban extends PureComponent<KanbanProps, KanbanState> {
             $nin: archivedStates,
           },
           $eager: 'pointPartners',
+          $sort: {
+            createdAt: -1,
+          },
         },
       })) as Paginated<Company>;
       const ret = transformData(res.data);

--- a/server/seeds/company.ts
+++ b/server/seeds/company.ts
@@ -16,6 +16,7 @@ export const seed = async (knex: Knex) => {
       team: Team.Philadelphia,
       contactEmail: 'elon@tesla.io',
       companyLinks: JSON.stringify([]),
+      createdAt: new Date(1576917474794),
     },
     {
       name: faker.company.companyName(),


### PR DESCRIPTION
### Goal:
If company is in applied AND current date - pitch date >= 6 days then
-- put to the top of the stack
-- have red warning text (as shown)

### Notes
- This isn't quite working yet - is it an issue with how I'm setting createdAt in seeds?
- Trying to get {this.props.company.createdAt} doesn't print anything

Not directly related to above issue:
- Could try to use json property in typeformdata on company model and sort by actual application date instead of when the company model was created on our server (would have to convert that to an attribute on the company model to use in sql queries, I believe) ... or could pass it as props and in column.tsx do more in memory sorting, but I reckon that's messy and we want to do less of that as is (shouldn't load whole thing into memory when db query can handle it)
