### PR TITLE
Fix company profile grid

### DIFF
--- a/client/components/CompanyProfile/CompanyProfile.tsx
+++ b/client/components/CompanyProfile/CompanyProfile.tsx
@@ -129,14 +129,16 @@ export default withAC(
             {company.companyLinks && (
               <p>
                 {company.companyLinks.map(({ name, url }) => (
-                  <a
-                    key={name}
-                    href={url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    {name}
-                  </a>
+                  <div>
+                    <a
+                      key={name}
+                      href={url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {`${name} `}
+                    </a>
+                  </div>
                 ))}
               </p>
             )}

--- a/client/components/CompanyProfile/CompanyProfile.tsx
+++ b/client/components/CompanyProfile/CompanyProfile.tsx
@@ -123,11 +123,6 @@ export default withAC(
               currentPartnerTeam={company.team}
             />
           </Col>
-          <Col md="2" className="float-right text-right">
-            <small>Pitch Date</small>
-            <br />
-            <p>{dayjs(company.createdAt).format('MMMM D, YYYY')}</p>
-          </Col>
         </HeaderRow>
         <HeaderRow>
           <Col md="8">


### PR DESCRIPTION
from
<img width="1423" alt="Screen Shot 2020-02-03 at 11 39 47 AM" src="https://user-images.githubusercontent.com/24398939/73673881-6e15cc00-467d-11ea-9226-5100aeb2d2d8.png">

to
<img width="1440" alt="Screen Shot 2020-02-04 at 5 24 02 PM" src="https://user-images.githubusercontent.com/24398939/73793264-08583b80-4774-11ea-869f-62d5fc34d352.png">

Ideally in future can move up the links to align with other info.

NOTE: 

Two options:

1. [Current] If a company isn't pitching, the `pitch date` text and actual date won't show up unless the company is in pitching state (i.e. all you would see is the partner team dropdown on that row). 

2. [Alternative] Have `Pitch date` text  always show up regardless of state and say 'Date not set' where not set or state isn't pitching.

Imo, go with option 1 - No need to see pitch date if it's in `applied` state. Easily reversible decision and can get partner feedback. Might be helpful to see pitch date if it's not in Applied, though, to reference back. Can ask partners for a future quick change.
